### PR TITLE
Build turbine against BTech 1.3.0

### DIFF
--- a/Properties/AssemblyInfo.cs
+++ b/Properties/AssemblyInfo.cs
@@ -32,5 +32,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion( "1.1.0.8" )]
-[assembly: AssemblyFileVersion( "1.1.0.8" )]
+[assembly: AssemblyVersion( "1.1.0.9" )]
+[assembly: AssemblyFileVersion( "1.1.0.9" )]

--- a/src/Mod.cs
+++ b/src/Mod.cs
@@ -303,7 +303,7 @@ namespace Sheepy.BattleTechMod.Turbine {
                   me.RemoveObjectOfType( request.ResourceId, request.ResourceType );
                if ( request.AlreadyLoaded ) {
                   if ( ! request.DependenciesLoaded( ___foregroundRequestsCurrentAllowedWeight ) ) {
-                     DataManager.ILoadDependencies dependencyLoader = request.TryGetLoadDependencies();
+                     DataManager.ILoadDependencies dependencyLoader = request.TryGetDependencyLoader();
                      if ( dependencyLoader != null ) {
                         request.RequestWeight.SetAllowedWeight( ___foregroundRequestsCurrentAllowedWeight );
                         dependencyLoader.RequestDependencies( me, () => {
@@ -364,7 +364,7 @@ namespace Sheepy.BattleTechMod.Turbine {
                   me.RemoveObjectOfType( request.ResourceId, request.ResourceType );
                if ( request.AlreadyLoaded ) {
                   if ( !request.DependenciesLoaded( ___backgroundRequestsCurrentAllowedWeight ) ) {
-                     DataManager.ILoadDependencies dependencyLoader = request.TryGetLoadDependencies();
+                     DataManager.ILoadDependencies dependencyLoader = request.TryGetDependencyLoader();
                      if ( dependencyLoader != null ) {
                         request.RequestWeight.SetAllowedWeight( ___backgroundRequestsCurrentAllowedWeight );
                         dependencyLoader.RequestDependencies( me, () => {


### PR DESCRIPTION
Other than a rename, not much that would break Turbine seems to have changed.

I just did a quick replace and built as 1.1.0.9 temporarily